### PR TITLE
Fix callable check for closure routes

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -33,7 +33,7 @@ class Guard
             $isAllowed = $isAllowed || $this->acl->isAllowed($this->currentUserRole, 'route'.$request->getAttribute('route')->getPattern(), strtolower($request->getMethod()));
         }
 
-        if ($this->acl->hasResource('callable/'.$request->getAttribute('route')->getCallable())) {
+        if (is_string($request->getAttribute('route')->getCallable()) && $this->acl->hasResource('callable/'.$request->getAttribute('route')->getCallable())) {
             $isAllowed = $isAllowed || $this->acl->isAllowed($this->currentUserRole, 'callable/'.$request->getAttribute('route')->getCallable());
         }
 


### PR DESCRIPTION
Check whether the callable is a string and perform
the callable acl check only in that case, to prevent a php error:

```
slim-acl/src/Guard.php:37
Object of class Closure could not be converted to string
```